### PR TITLE
add script for local development on macs (in docker)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM rust:1.32.0
 
+RUN cargo install cargo-watch
+
 WORKDIR /root/check-protocols
 ADD Cargo.* ./
 RUN mkdir src && touch src/lib.rs && cargo install --root /usr/local --path . ; true

--- a/README.md
+++ b/README.md
@@ -126,5 +126,6 @@ run inside of docker. Luckily, we have set up a one-liner for you. This will run
 within docker, when files change:
 
 ``` bash
+./build-docker-image.sh
 ./test-watch-in-docker.sh
 ```

--- a/README.md
+++ b/README.md
@@ -102,11 +102,29 @@ protocol:
   - git pull
 ```
 
-## Running inside `docker`
+## Running inside `docker` (for OSX)
 
 You can run the tool inside docker, for example like this:
 
 ``` bash
 ./build-docker-image.sh
 ./check-protocols-in-docker.sh <PATH_TO_YOUR_SCRIPT>
+```
+
+## Contributing
+
+Contributions, feature requests, bug reports, etc. are all welcome. Please consider the following guidelines
+when submitting:
+
+* For any pull request that you intend to merge, we ask that all tests pass for every commit that will end up on master
+* We will address the top rated (by :thumbsup:) issues first, please cast your votes!
+
+### For OSX
+
+This tool does not currently compile or run on OSX. In order to develop on a Mac you will need to
+run inside of docker. Luckily, we have set up a one-liner for you. This will run the tests continuously,
+within docker, when files change:
+
+``` bash
+./test-watch-in-docker.sh
 ```

--- a/test-watch-in-docker.sh
+++ b/test-watch-in-docker.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+docker run --init --rm -it --cap-add=SYS_PTRACE \
+  --entrypoint "/bin/bash" -v $(pwd):/root/ \
+  check-protocols -c "cargo watch -x 'test -- --test-threads=1 --quiet'"


### PR DESCRIPTION
i went to start adding a feature (#72) and realized that local development on OSX wasn't very smooth. this PR adds [cargo-watch](https://github.com/passcod/cargo-watch) to the docker image and creates a script to run the tests continuously within docker.

Closes #74.