### PR TITLE
trace commands that are executed using vfork

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,11 @@ jobs:
       - image: rust:1.32.0-stretch
 
     steps:
+      - run:
+          name: install ruby
+          command: |
+            apt update
+            apt install --yes ruby
       - checkout
       - run:
           name: check formatting

--- a/src/syscall_mocking/mod.rs
+++ b/src/syscall_mocking/mod.rs
@@ -69,7 +69,9 @@ impl Tracer {
                 waitpid(tracee_pid, None)?;
                 ptrace::setoptions(
                     tracee_pid,
-                    Options::PTRACE_O_TRACESYSGOOD | Options::PTRACE_O_TRACEFORK,
+                    Options::PTRACE_O_TRACESYSGOOD
+                        | Options::PTRACE_O_TRACEFORK
+                        | Options::PTRACE_O_TRACEVFORK,
                 )?;
                 ptrace::syscall(tracee_pid)?;
 

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -510,3 +510,19 @@ fn failure_when_the_tested_script_exits_with_a_non_zero_exitcode() -> R<()> {
     )?;
     Ok(())
 }
+
+#[test]
+fn detects_running_commands_from_ruby_scripts() -> R<()> {
+    test_run(
+        r##"
+            |#!/usr/bin/env ruby
+            |`ls`
+        "##,
+        r##"
+            |protocol:
+            |  - /bin/ls
+        "##,
+        Ok(()),
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
This is how some languages, e.g. ruby, execute subprocesses.

Fixes #81.