### PR TITLE
allow to specify the directory the tested script is running in

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ env?:
   # Environment being passed into the tested script.
   # Example: PREFIX: /usr/local/, default: {}
   { [string]: string }
+cwd?: string
+  # Current working directory the tested script will be executed in.
+  # Example: /test-dir, default: same directory that `check-protocols` is run in.
 protocol:
   # List of commands that your script is expected to execute.
   - command: string

--- a/check-protocols-in-docker.sh
+++ b/check-protocols-in-docker.sh
@@ -2,10 +2,12 @@
 
 script=$1
 if [[ "$script" = /* ]]; then
-  docker run --rm -it --cap-add=SYS_PTRACE \
-    --mount type=bind,source=$script,target=/root/$(basename $script) \
-    --mount type=bind,source=$script.protocols.yaml,target=/root/$(basename $script).protocols.yaml \
-    check-protocols $(basename $script)
+  true
 else
-  echo please supply an absolute path
+  script=$(pwd)/$script
 fi
+
+docker run --rm -it --cap-add=SYS_PTRACE \
+  --mount type=bind,source=$script,target=/root/$(basename $script) \
+  --mount type=bind,source=$script.protocols.yaml,target=/root/$(basename $script).protocols.yaml \
+  check-protocols $(basename $script)

--- a/check-protocols-in-docker.sh.protocols.yaml
+++ b/check-protocols-in-docker.sh.protocols.yaml
@@ -1,7 +1,20 @@
-# doesn't do anything for relative paths
-arguments: ./relative_path
-protocol: []
+# works for relative paths
+arguments: ./script
+cwd: /basedir
+protocol:
+  - command: /usr/bin/basename /basedir/./script
+    stdout: script
+  - command: /usr/bin/basename /basedir/./script
+    stdout: script
+  - command: /usr/bin/basename /basedir/./script
+    stdout: script
+  - /usr/bin/docker run --rm -it
+    --cap-add=SYS_PTRACE
+    --mount type=bind,source=/basedir/./script,target=/root/script
+    --mount type=bind,source=/basedir/./script.protocols.yaml,target=/root/script.protocols.yaml
+    check-protocols script
 ---
+# works for absolute paths
 arguments: /test/script
 protocol:
   - command: /usr/bin/basename /test/script

--- a/src/emulation/mod.rs
+++ b/src/emulation/mod.rs
@@ -42,10 +42,7 @@ impl SyscallMock {
     ) -> R<()> {
         if let (Syscall::Execve, SyscallStop::Enter) = (&syscall, syscall_stop) {
             if self.tracee_pid != pid {
-                let executable = tracee_memory::data_to_string(tracee_memory::peekdata_iter(
-                    pid,
-                    registers.rdi,
-                ))?;
+                let executable = tracee_memory::peek_string(pid, registers.rdi)?;
                 let arguments = tracee_memory::peek_string_array(pid, registers.rsi)?;
                 let mock_executable_path = self.handle_step(protocol::Command {
                     executable,

--- a/src/emulation/mod.rs
+++ b/src/emulation/mod.rs
@@ -48,10 +48,10 @@ impl SyscallMock {
                     executable,
                     arguments,
                 })?;
-                tracee_memory::pokedata(
+                tracee_memory::poke_string(
                     pid,
                     registers.rdi,
-                    tracee_memory::string_to_data(path_to_string(&mock_executable_path)?)?,
+                    path_to_string(&mock_executable_path)?,
                 )?;
             }
         }

--- a/src/emulation/mod.rs
+++ b/src/emulation/mod.rs
@@ -48,7 +48,7 @@ impl SyscallMock {
                     executable,
                     arguments,
                 })?;
-                tracee_memory::poke_string(
+                tracee_memory::poke_single_word_string(
                     pid,
                     registers.rdi,
                     &mock_executable_path.as_os_str().as_bytes(),

--- a/src/emulation/mod.rs
+++ b/src/emulation/mod.rs
@@ -42,12 +42,8 @@ impl SyscallMock {
     ) -> R<()> {
         if let (Syscall::Execve, SyscallStop::Enter) = (&syscall, syscall_stop) {
             if self.tracee_pid != pid {
-                let executable =
-                    String::from_utf8(tracee_memory::peek_string(pid, registers.rdi)?)?;
-                let arguments = tracee_memory::peek_string_array(pid, registers.rsi)?
-                    .into_iter()
-                    .map(String::from_utf8)
-                    .collect::<Result<Vec<String>, _>>()?;
+                let executable = tracee_memory::peek_string(pid, registers.rdi)?;
+                let arguments = tracee_memory::peek_string_array(pid, registers.rsi)?;
                 let mock_executable_path = self.handle_step(protocol::Command {
                     executable,
                     arguments,
@@ -156,7 +152,7 @@ mod run_against_protocol {
                 &script.path(),
                 Protocol::new(vec![protocol::Step {
                     command: Command {
-                        executable: long_command.path().to_string_lossy().into_owned(),
+                        executable: long_command.path().as_os_str().as_bytes().to_vec(),
                         arguments: vec![],
                     },
                     stdout: vec![],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(feature = "dev", allow(dead_code, unused_variables, unused_imports))]
 #![cfg_attr(feature = "ci", deny(warnings))]
 #![deny(clippy::all)]
+#![allow(clippy::needless_range_loop)]
 #![cfg_attr(test, allow(clippy::module_inception))]
 
 #[macro_use]

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -75,7 +75,7 @@ mod parse_step {
             test_parse_step(r#""foo""#)?,
             Step {
                 command: Command {
-                    executable: "foo".to_string(),
+                    executable: b"foo".to_vec(),
                     arguments: vec![],
                 },
                 stdout: vec![],
@@ -90,8 +90,8 @@ mod parse_step {
         assert_eq!(
             test_parse_step(r#""foo bar""#)?.command,
             Command {
-                executable: "foo".to_string(),
-                arguments: vec!["bar".to_string()],
+                executable: b"foo".to_vec(),
+                arguments: vec![b"bar".to_vec()],
             },
         );
         Ok(())
@@ -103,7 +103,7 @@ mod parse_step {
             test_parse_step(r#"{command: "foo"}"#)?,
             Step {
                 command: Command {
-                    executable: "foo".to_string(),
+                    executable: b"foo".to_vec(),
                     arguments: vec![],
                 },
                 stdout: vec![],
@@ -118,8 +118,8 @@ mod parse_step {
         assert_eq!(
             test_parse_step(r#"{command: "foo bar"}"#)?.command,
             Command {
-                executable: "foo".to_string(),
-                arguments: vec!["bar".to_string()],
+                executable: b"foo".to_vec(),
+                arguments: vec![b"bar".to_vec()],
             },
         );
         Ok(())
@@ -289,7 +289,7 @@ mod load {
             )?,
             Protocol::new(vec![Step {
                 command: Command {
-                    executable: "/bin/true".to_string(),
+                    executable: b"/bin/true".to_vec(),
                     arguments: vec![],
                 },
                 stdout: vec![],
@@ -318,7 +318,7 @@ mod load {
             )?
             .steps
             .map(|step| step.command.executable),
-            vec!["/bin/true", "/bin/false"],
+            vec![b"/bin/true".to_vec(), b"/bin/false".to_vec()],
         );
         Ok(())
     }
@@ -333,7 +333,7 @@ mod load {
             )?
             .steps
             .map(|step| step.command.arguments),
-            vec![vec!["foo", "bar"].map(String::from)],
+            vec![vec![b"foo".to_vec(), b"bar".to_vec()]],
         );
         Ok(())
     }
@@ -349,7 +349,7 @@ mod load {
             )?,
             Protocol::new(vec![Step {
                 command: Command {
-                    executable: "/bin/true".to_string(),
+                    executable: b"/bin/true".to_vec(),
                     arguments: vec![],
                 },
                 stdout: vec![],

--- a/src/syscall_mocking/tracee_memory.rs
+++ b/src/syscall_mocking/tracee_memory.rs
@@ -23,7 +23,7 @@ fn peekdata(pid: Pid, address: c_ulonglong) -> R<c_ulonglong> {
     Ok(ptrace::read(pid, address as *mut c_void)? as c_ulonglong)
 }
 
-pub fn peekdata_iter(pid: Pid, address: c_ulonglong) -> impl Iterator<Item = R<c_ulonglong>> {
+fn peekdata_iter(pid: Pid, address: c_ulonglong) -> impl Iterator<Item = R<c_ulonglong>> {
     struct Iter {
         pid: Pid,
         address: c_ulonglong,
@@ -42,7 +42,7 @@ pub fn peekdata_iter(pid: Pid, address: c_ulonglong) -> impl Iterator<Item = R<c
     Iter { pid, address }
 }
 
-pub fn data_to_string(data: impl Iterator<Item = R<c_ulonglong>>) -> R<String> {
+fn data_to_string(data: impl Iterator<Item = R<c_ulonglong>>) -> R<String> {
     let mut result = vec![];
     'outer: for word in data {
         for char in cast_to_byte_array(word?).iter() {
@@ -53,6 +53,10 @@ pub fn data_to_string(data: impl Iterator<Item = R<c_ulonglong>>) -> R<String> {
         }
     }
     Ok(String::from_utf8(result)?)
+}
+
+pub fn peek_string(pid: Pid, address: c_ulonglong) -> R<String> {
+    data_to_string(peekdata_iter(pid, address))
 }
 
 pub fn peek_string_array(pid: Pid, address: c_ulonglong) -> R<Vec<String>> {

--- a/src/syscall_mocking/tracee_memory.rs
+++ b/src/syscall_mocking/tracee_memory.rs
@@ -11,6 +11,14 @@ fn cast_to_byte_array(word: c_ulonglong) -> [u8; 8] {
     *ptr
 }
 
+fn cast_to_word(bytes: [u8; 8]) -> c_ulonglong {
+    let void_ptr;
+    unsafe {
+        void_ptr = std::mem::transmute(bytes);
+    }
+    void_ptr
+}
+
 fn peekdata(pid: Pid, address: c_ulonglong) -> R<c_ulonglong> {
     Ok(ptrace::read(pid, address as *mut c_void)? as c_ulonglong)
 }
@@ -60,12 +68,42 @@ pub fn peek_string_array(pid: Pid, address: c_ulonglong) -> R<Vec<String>> {
     Ok(result)
 }
 
-fn cast_to_word(bytes: [u8; 8]) -> c_ulonglong {
-    let void_ptr;
-    unsafe {
-        void_ptr = std::mem::transmute(bytes);
+#[cfg(test)]
+mod peeking {
+    use super::*;
+
+    #[test]
+    fn reads_null_terminated_strings_from_one_word() {
+        let data = vec![[102, 111, 111, 0, 0, 0, 0, 0]]
+            .into_iter()
+            .map(cast_to_word)
+            .map(Ok);
+        assert_eq!(data_to_string(data).unwrap(), "foo");
     }
-    void_ptr
+
+    #[test]
+    fn works_for_multiple_words() {
+        let data = vec![
+            [97, 98, 99, 100, 101, 102, 103, 104],
+            [105, 0, 0, 0, 0, 0, 0, 0],
+        ]
+        .into_iter()
+        .map(cast_to_word)
+        .map(Ok);
+        assert_eq!(data_to_string(data).unwrap(), "abcdefghi");
+    }
+
+    #[test]
+    fn works_when_null_is_on_the_edge() {
+        let data = vec![
+            [97, 98, 99, 100, 101, 102, 103, 104],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+        ]
+        .into_iter()
+        .map(cast_to_word)
+        .map(Ok);
+        assert_eq!(data_to_string(data).unwrap(), "abcdefgh");
+    }
 }
 
 pub fn pokedata(pid: Pid, address: c_ulonglong, words: c_ulonglong) -> R<()> {
@@ -86,126 +124,84 @@ pub fn string_to_data(string: &str) -> R<c_ulonglong> {
 }
 
 #[cfg(test)]
-mod test {
+mod poking {
     use super::*;
+    use crate::syscall_mocking::fork_with_child_errors;
+    use nix::sys::ptrace::Options;
+    use nix::sys::signal;
+    use nix::sys::signal::Signal;
+    use nix::sys::wait::{waitpid, WaitStatus};
+    use nix::unistd::{execv, getpid};
+    use std::ffi::CString;
+    use test_utils::assert_error;
 
-    mod peeking {
+    mod string_to_data {
         use super::*;
 
         #[test]
-        fn reads_null_terminated_strings_from_one_word() {
-            let data = vec![[102, 111, 111, 0, 0, 0, 0, 0]]
-                .into_iter()
-                .map(cast_to_word)
-                .map(Ok);
-            assert_eq!(data_to_string(data).unwrap(), "foo");
+        fn converts_strings_to_bytes() -> R<()> {
+            assert_eq!(
+                string_to_data("foo")?,
+                cast_to_word([102, 111, 111, 0, 0, 0, 0, 0])
+            );
+            Ok(())
         }
 
         #[test]
-        fn works_for_multiple_words() {
-            let data = vec![
-                [97, 98, 99, 100, 101, 102, 103, 104],
-                [105, 0, 0, 0, 0, 0, 0, 0],
-            ]
-            .into_iter()
-            .map(cast_to_word)
-            .map(Ok);
-            assert_eq!(data_to_string(data).unwrap(), "abcdefghi");
-        }
-
-        #[test]
-        fn works_when_null_is_on_the_edge() {
-            let data = vec![
-                [97, 98, 99, 100, 101, 102, 103, 104],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-            ]
-            .into_iter()
-            .map(cast_to_word)
-            .map(Ok);
-            assert_eq!(data_to_string(data).unwrap(), "abcdefgh");
+        fn errors_on_too_long_strings() -> R<()> {
+            assert_error!(
+                string_to_data("1234567890"),
+                "string_to_data: string too long"
+            );
+            assert_error!(
+                string_to_data("12345678"),
+                "string_to_data: string too long"
+            );
+            assert_eq!(
+                string_to_data("1234567")?,
+                cast_to_word([49, 50, 51, 52, 53, 54, 55, 0])
+            );
+            Ok(())
         }
     }
 
-    mod poking {
-        use super::*;
-        use crate::syscall_mocking::fork_with_child_errors;
-        use nix::sys::ptrace::Options;
-        use nix::sys::signal;
-        use nix::sys::signal::Signal;
-        use nix::sys::wait::{waitpid, WaitStatus};
-        use nix::unistd::{execv, getpid};
-        use std::ffi::CString;
-        use test_utils::assert_error;
-
-        mod string_to_data {
-            use super::*;
-
-            #[test]
-            fn converts_strings_to_bytes() -> R<()> {
-                assert_eq!(
-                    string_to_data("foo")?,
-                    cast_to_word([102, 111, 111, 0, 0, 0, 0, 0])
-                );
+    #[test]
+    fn roundtrip() -> R<()> {
+        let fork_result = fork_with_child_errors(
+            || {
+                ptrace::traceme()?;
+                signal::kill(getpid(), Some(Signal::SIGSTOP))?;
+                let path = CString::new("/bin/true")?;
+                execv(&path, &[path.clone()])?;
                 Ok(())
-            }
+            },
+            |child| -> R<()> {
+                waitpid(child, None)?;
+                ptrace::setoptions(child, Options::PTRACE_O_TRACESYSGOOD)?;
+                ptrace::syscall(child)?;
 
-            #[test]
-            fn errors_on_too_long_strings() -> R<()> {
-                assert_error!(
-                    string_to_data("1234567890"),
-                    "string_to_data: string too long"
-                );
-                assert_error!(
-                    string_to_data("12345678"),
-                    "string_to_data: string too long"
-                );
-                assert_eq!(
-                    string_to_data("1234567")?,
-                    cast_to_word([49, 50, 51, 52, 53, 54, 55, 0])
-                );
-                Ok(())
-            }
-        }
-
-        #[test]
-        fn roundtrip() -> R<()> {
-            let fork_result = fork_with_child_errors(
-                || {
-                    ptrace::traceme()?;
-                    signal::kill(getpid(), Some(Signal::SIGSTOP))?;
-                    let path = CString::new("/bin/true")?;
-                    execv(&path, &[path.clone()])?;
-                    Ok(())
-                },
-                |child| -> R<()> {
-                    waitpid(child, None)?;
-                    ptrace::setoptions(child, Options::PTRACE_O_TRACESYSGOOD)?;
-                    ptrace::syscall(child)?;
-
-                    loop {
-                        let status = waitpid(child, None)?;
-                        match status {
-                            WaitStatus::Exited(..) => {
-                                break;
-                            }
-                            WaitStatus::PtraceSyscall(..) => {
-                                let registers = ptrace::getregs(child)?;
-                                if registers.orig_rax == libc::SYS_execve as c_ulonglong {
-                                    pokedata(child, registers.rdi, string_to_data("/foo")?)?;
-                                    let result =
-                                        data_to_string(peekdata_iter(child, registers.rdi))?;
-                                    assert_eq!(result, "/foo");
-                                }
-                            }
-                            _ => {}
+                loop {
+                    let status = waitpid(child, None)?;
+                    match status {
+                        WaitStatus::Exited(..) => {
+                            break;
                         }
-                        ptrace::syscall(child)?;
+                        WaitStatus::PtraceSyscall(..) => {
+                            let registers = ptrace::getregs(child)?;
+                            if registers.orig_rax == libc::SYS_execve as c_ulonglong {
+                                pokedata(child, registers.rdi, string_to_data("/foo")?)?;
+                                let result = data_to_string(peekdata_iter(child, registers.rdi))?;
+                                assert_eq!(result, "/foo");
+                            }
+                        }
+                        _ => {}
                     }
-                    Ok(())
-                },
-            );
-            assert_error!(fork_result, "ENOENT: No such file or directory");
-            Ok(())
-        }
+                    ptrace::syscall(child)?;
+                }
+                Ok(())
+            },
+        );
+        assert_error!(fork_result, "ENOENT: No such file or directory");
+        Ok(())
     }
 }

--- a/src/syscall_mocking/tracee_memory.rs
+++ b/src/syscall_mocking/tracee_memory.rs
@@ -115,8 +115,8 @@ fn pokedata(pid: Pid, address: c_ulonglong, words: c_ulonglong) -> R<()> {
     Ok(())
 }
 
-fn string_to_data(string: &[u8], max_size: usize) -> R<Vec<c_ulonglong>> {
-    if string.len() >= max_size {
+fn string_to_data(string: &[u8], max_size: c_ulonglong) -> R<Vec<c_ulonglong>> {
+    if string.len() as c_ulonglong >= max_size {
         Err("string_to_data: string too long")?
     } else {
         let mut result = vec![];
@@ -134,7 +134,12 @@ fn string_to_data(string: &[u8], max_size: usize) -> R<Vec<c_ulonglong>> {
     }
 }
 
-pub fn poke_string(pid: Pid, mut address: c_ulonglong, string: &[u8], max_size: usize) -> R<()> {
+pub fn poke_string(
+    pid: Pid,
+    mut address: c_ulonglong,
+    string: &[u8],
+    max_size: c_ulonglong,
+) -> R<()> {
     for word in string_to_data(string, max_size)? {
         pokedata(pid, address, word)?;
         address += 8;

--- a/src/syscall_mocking/tracee_memory.rs
+++ b/src/syscall_mocking/tracee_memory.rs
@@ -110,12 +110,12 @@ mod peeking {
     }
 }
 
-pub fn pokedata(pid: Pid, address: c_ulonglong, words: c_ulonglong) -> R<()> {
+fn pokedata(pid: Pid, address: c_ulonglong, words: c_ulonglong) -> R<()> {
     ptrace::write(pid, address as *mut c_void, words as *mut c_void)?;
     Ok(())
 }
 
-pub fn string_to_data(string: &str) -> R<c_ulonglong> {
+fn string_to_data(string: &str) -> R<c_ulonglong> {
     if string.len() >= 8 {
         Err("string_to_data: string too long")?
     } else {
@@ -125,6 +125,10 @@ pub fn string_to_data(string: &str) -> R<c_ulonglong> {
         }
         Ok(cast_to_word(result))
     }
+}
+
+pub fn poke_string(pid: Pid, address: c_ulonglong, string: &str) -> R<()> {
+    pokedata(pid, address, string_to_data(string)?)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This will e.g. allow to use `pwd` in scripts and control through the protocols file what that returns. (`pwd` is not an executable, but a shell builtin.)

Fixes #48.