### PR TITLE
add ruby to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM rust:1.32.0
 
 RUN cargo install cargo-watch
+RUN apt-get update && apt-get install -y ruby
 
 WORKDIR /root/check-protocols
 ADD Cargo.* ./


### PR DESCRIPTION
the tests currently fail within docker (using `test-watch-in-docker.sh`) because the tests depend on the existence of ruby. this fixes that.

@soenkehahn would it make sense for circle to run the tests within the same container that is used for local development?