### PR TITLE
assert that tracee_memory roundtrip tests have lots of memory to poke…

### DIFF
--- a/src/syscall_mocking/tracee_memory.rs
+++ b/src/syscall_mocking/tracee_memory.rs
@@ -261,6 +261,7 @@ mod poking {
                             WaitStatus::PtraceSyscall(..) => {
                                 let registers = ptrace::getregs(child)?;
                                 if registers.orig_rax == libc::SYS_getcwd as c_ulonglong {
+                                    assert!(registers.rsi >= 512);
                                     test(child, registers)?;
                                 }
                             }


### PR DESCRIPTION
… around in