### PR TITLE
filetree mocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "bincode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -85,6 +86,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "linked-hash-map"
 version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memoffset"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -272,6 +278,7 @@ dependencies = [
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
+"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46f0f3210768d796e8fa79ec70ee6af172dacbe7147f5e69be5240a47778302b"
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ linked-hash-map = "*"
 bincode = "*"
 serde_derive = "*"
 serde = "*"
+memoffset = "*"
 
 [build-dependencies]
 trim-margin = "*"

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ protocols:
         exitcode?: number
           # Mocked exitcode of the command.
           # Default: 0
+        mockedFiles?: [string]
+          # List of files and folders that are going to be mocked to exist.
+          # Note that directories must include a trailing '/'.
+          # Example: ["/www/logs"], default: []
 interpreter?: string
     # The interpreter that should be used to run the tested script.
     # Example: "/bin/bash", default: The program itself will be executed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
+extern crate memoffset;
 
 mod cli;
 mod protocol;

--- a/src/tracer/tracee_memory.rs
+++ b/src/tracer/tracee_memory.rs
@@ -1,22 +1,39 @@
 use crate::R;
-use libc::{c_ulonglong, c_void};
+use libc::{c_uint, c_ulonglong, c_void};
 use nix::sys::ptrace;
 use nix::unistd::Pid;
 
-fn cast_to_byte_array(word: c_ulonglong) -> [u8; 8] {
-    let ptr: &[u8; 8];
-    unsafe {
-        ptr = &*(&word as *const u64 as *const [u8; 8]);
-    }
-    *ptr
+fn cast_to_four_byte_array(x: c_uint) -> [u8; 4] {
+    [
+        (x & 0xff) as u8,
+        ((x >> 8) & 0xff) as u8,
+        ((x >> 16) & 0xff) as u8,
+        ((x >> 24) & 0xff) as u8,
+    ]
 }
 
-fn cast_to_word(bytes: [u8; 8]) -> c_ulonglong {
-    let void_ptr;
-    unsafe {
-        void_ptr = std::mem::transmute(bytes);
-    }
-    void_ptr
+fn cast_to_eight_byte_array(x: c_ulonglong) -> [u8; 8] {
+    [
+        (x & 0xff) as u8,
+        ((x >> 8) & 0xff) as u8,
+        ((x >> 16) & 0xff) as u8,
+        ((x >> 24) & 0xff) as u8,
+        ((x >> 32) & 0xff) as u8,
+        ((x >> 40) & 0xff) as u8,
+        ((x >> 48) & 0xff) as u8,
+        ((x >> 56) & 0xff) as u8,
+    ]
+}
+
+fn cast_to_eight_byte_word(bytes: [u8; 8]) -> c_ulonglong {
+    u64::from(bytes[0])
+        + (u64::from(bytes[1]) << 8)
+        + (u64::from(bytes[2]) << 16)
+        + (u64::from(bytes[3]) << 24)
+        + (u64::from(bytes[4]) << 32)
+        + (u64::from(bytes[5]) << 40)
+        + (u64::from(bytes[6]) << 48)
+        + (u64::from(bytes[7]) << 56)
 }
 
 fn peekdata(pid: Pid, address: c_ulonglong) -> R<c_ulonglong> {
@@ -45,7 +62,7 @@ fn peekdata_iter(pid: Pid, address: c_ulonglong) -> impl Iterator<Item = R<c_ulo
 fn data_to_string(data: impl Iterator<Item = R<c_ulonglong>>) -> R<Vec<u8>> {
     let mut result = vec![];
     'outer: for word in data {
-        for char in cast_to_byte_array(word?).iter() {
+        for char in cast_to_eight_byte_array(word?).iter() {
             if *char == 0 {
                 break 'outer;
             }
@@ -80,7 +97,7 @@ mod peeking {
     fn reads_null_terminated_strings_from_one_word() {
         let data = vec![[102, 111, 111, 0, 0, 0, 0, 0]]
             .into_iter()
-            .map(cast_to_word)
+            .map(cast_to_eight_byte_word)
             .map(Ok);
         assert_eq!(data_to_string(data).unwrap(), b"foo");
     }
@@ -92,7 +109,7 @@ mod peeking {
             [105, 0, 0, 0, 0, 0, 0, 0],
         ]
         .into_iter()
-        .map(cast_to_word)
+        .map(cast_to_eight_byte_word)
         .map(Ok);
         assert_eq!(data_to_string(data).unwrap(), b"abcdefghi");
     }
@@ -104,10 +121,21 @@ mod peeking {
             [0, 0, 0, 0, 0, 0, 0, 0],
         ]
         .into_iter()
-        .map(cast_to_word)
+        .map(cast_to_eight_byte_word)
         .map(Ok);
         assert_eq!(data_to_string(data).unwrap(), b"abcdefgh");
     }
+}
+
+pub fn poke_four_bytes(pid: Pid, address: c_ulonglong, small_word: c_uint) -> R<()> {
+    let existing_word: c_ulonglong = peekdata(pid, address)?;
+    let mut overlapping_data_array: [u8; 8] = cast_to_eight_byte_array(existing_word);
+
+    let first_four_bytes: [u8; 4] = cast_to_four_byte_array(small_word);
+    overlapping_data_array[..4].clone_from_slice(&first_four_bytes);
+
+    let new_word: c_ulonglong = cast_to_eight_byte_word(overlapping_data_array);
+    pokedata(pid, address, new_word)
 }
 
 fn pokedata(pid: Pid, address: c_ulonglong, words: c_ulonglong) -> R<()> {
@@ -128,7 +156,7 @@ fn string_to_data(string: &[u8], max_size: c_ulonglong) -> R<Vec<c_ulonglong>> {
                     word[i] = *char;
                 }
             }
-            result.push(cast_to_word(word));
+            result.push(cast_to_eight_byte_word(word));
         }
         Ok(result)
     }
@@ -171,7 +199,7 @@ mod poking {
         fn converts_strings_to_bytes() -> R<()> {
             assert_eq!(
                 string_to_data(b"foo", 8)?,
-                vec![cast_to_word([102, 111, 111, 0, 0, 0, 0, 0])]
+                vec![cast_to_eight_byte_word([102, 111, 111, 0, 0, 0, 0, 0])]
             );
             Ok(())
         }
@@ -181,8 +209,8 @@ mod poking {
             assert_eq!(
                 string_to_data(b"foo_foo_foo", 16)?,
                 vec![
-                    cast_to_word([102, 111, 111, 95, 102, 111, 111, 95]),
-                    cast_to_word([102, 111, 111, 0, 0, 0, 0, 0]),
+                    cast_to_eight_byte_word([102, 111, 111, 95, 102, 111, 111, 95]),
+                    cast_to_eight_byte_word([102, 111, 111, 0, 0, 0, 0, 0]),
                 ]
             );
             Ok(())
@@ -200,7 +228,7 @@ mod poking {
             );
             assert_eq!(
                 string_to_data(b"1234567", 8)?,
-                vec![cast_to_word([49, 50, 51, 52, 53, 54, 55, 0])]
+                vec![cast_to_eight_byte_word([49, 50, 51, 52, 53, 54, 55, 0])]
             );
             assert_error!(
                 string_to_data(b"123456781234567890", 16),
@@ -213,8 +241,8 @@ mod poking {
             assert_eq!(
                 string_to_data(b"123456781234567", 16)?,
                 vec![
-                    cast_to_word([49, 50, 51, 52, 53, 54, 55, 56]),
-                    cast_to_word([49, 50, 51, 52, 53, 54, 55, 0])
+                    cast_to_eight_byte_word([49, 50, 51, 52, 53, 54, 55, 56]),
+                    cast_to_eight_byte_word([49, 50, 51, 52, 53, 54, 55, 0])
                 ]
             );
             Ok(())
@@ -225,8 +253,8 @@ mod poking {
             assert_eq!(
                 string_to_data(b"12345678", 16)?,
                 vec![
-                    cast_to_word([49, 50, 51, 52, 53, 54, 55, 56]),
-                    cast_to_word([0, 0, 0, 0, 0, 0, 0, 0])
+                    cast_to_eight_byte_word([49, 50, 51, 52, 53, 54, 55, 56]),
+                    cast_to_eight_byte_word([0, 0, 0, 0, 0, 0, 0, 0])
                 ]
             );
             Ok(())
@@ -236,6 +264,13 @@ mod poking {
     mod roundtrip {
         use super::*;
         use libc::user_regs_struct;
+
+        fn cast_to_four_byte_word(bytes: [u8; 4]) -> c_uint {
+            u32::from(bytes[0])
+                + (u32::from(bytes[1]) << 8)
+                + (u32::from(bytes[2]) << 16)
+                + (u32::from(bytes[3]) << 24)
+        }
 
         fn run_roundtrip_test(test: fn(child: Pid, registers: user_regs_struct) -> R<()>) -> R<()> {
             fork_with_child_errors(
@@ -277,6 +312,23 @@ mod poking {
         #[test]
         fn run_roundtrip_test_runs_the_given_test() {
             assert_error!(run_roundtrip_test(|_, _| Err("foo")?), "foo");
+        }
+
+        #[test]
+        fn roundtrip_for_four_byte_word_doesnt_clobber_adjacent_four_bytes() -> R<()> {
+            run_roundtrip_test(|child, registers| {
+                let eight_bytes: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+                let four_bytes: [u8; 4] = [10, 20, 30, 40];
+
+                pokedata(child, registers.rdi, cast_to_eight_byte_word(eight_bytes))?;
+                poke_four_bytes(child, registers.rdi, cast_to_four_byte_word(four_bytes))?;
+
+                assert_eq!(
+                    cast_to_eight_byte_array(peekdata(child, registers.rdi)?),
+                    [10, 20, 30, 40, 5, 6, 7, 8],
+                );
+                Ok(())
+            })
         }
 
         #[test]

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -891,3 +891,67 @@ mod unmocked_commands {
         Ok(())
     }
 }
+
+mod file_mocking {
+    use super::*;
+
+    #[test]
+    fn allows_to_mock_files_existence() -> R<()> {
+        test_run(
+            r##"
+                |#!/usr/bin/env bash
+                |if [ -f /foo ]; then
+                |  /bin/true
+                |fi
+            "##,
+            r##"
+                |protocols:
+                |  - protocol:
+                |      - /bin/true
+                |    mockedFiles:
+                |      - /foo
+            "##,
+            Ok(()),
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn allows_to_mock_directory_existence() -> R<()> {
+        test_run(
+            r##"
+                |#!/usr/bin/env bash
+                |if [ -d /foo/ ]; then
+                |  /bin/true
+                |fi
+            "##,
+            r##"
+                |protocols:
+                |  - protocol:
+                |      - command: /bin/true
+                |    mockedFiles:
+                |      - /foo/
+            "##,
+            Ok(()),
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn does_not_mock_existence_of_unspecified_files() -> R<()> {
+        test_run(
+            r##"
+                |#!/usr/bin/env bash
+                |if [ -f /foo ]; then
+                |  /bin/true
+                |fi
+            "##,
+            r##"
+                |protocols:
+                |  - protocol: []
+            "##,
+            Ok(()),
+        )?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
reopening a clean version of #112. i believe this is ready for review now. the only open question i am aware of is whether `filetree` is what we want to call it. 

~~also there appears to be some nondeterministic error with this on CI that i can't reproduce locally. i'll try to hunt this down tomorrow.~~ ...now that i can write to the `statbuf`, i can do it for a regular file too, which i believe fixed the issue on CI (and it means that we no longer need to edit the `Dockerfile`)

closes #72 