### PR TITLE
implement expected stderr for protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ protocols:
     cwd?: string
       # Current working directory the tested script will be executed in.
       # Example: /test-dir, default: same directory that `check-protocols` is run in.
+    stderr?: string
+      # Output that the script is expected to write to stderr.
+      # Example: "error message\n", default: stderr output is not checked.
     exitcode?: number
       # Exitcode that the tested script is expected to exit with.
       # Default: 0.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ use crate::context::Context;
 use crate::protocol::{Protocol, Protocols};
 use crate::syscall_mock::test_result::{TestResult, TestResults};
 use crate::syscall_mock::{executable_mock, SyscallMock};
+use crate::tracer::stdio_redirecting::CaptureStderr;
 use crate::tracer::Tracer;
 use std::io::Write;
 use std::path::Path;
@@ -159,6 +160,11 @@ pub fn run_against_protocol(
         program,
         expected.arguments.clone(),
         expected.env.clone(),
+        if expected.stderr.is_some() {
+            CaptureStderr::Capture
+        } else {
+            CaptureStderr::NoCapture
+        },
         |tracee_pid| SyscallMock::new(context, tracee_pid, expected, unmocked_commands),
     )
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -170,7 +170,7 @@ pub struct Protocol {
     pub arguments: Vec<String>,
     pub env: HashMap<String, String>,
     pub cwd: Option<Vec<u8>>,
-    stderr: Option<Vec<u8>>,
+    pub stderr: Option<Vec<u8>>,
     pub exitcode: i32,
     pub mocked_files: Vec<Vec<u8>>,
 }

--- a/src/tracer/mod.rs
+++ b/src/tracer/mod.rs
@@ -143,11 +143,12 @@ impl Tracer {
                         | Options::PTRACE_O_TRACEVFORK,
                 )?;
                 ptrace::syscall(tracee_pid)?;
-
                 let mut tracer = Tracer::new(tracee_pid, mk_syscall_mock(tracee_pid));
                 let exitcode = tracer.trace()?;
                 join()?;
-                Ok(tracer.syscall_mock.handle_end(exitcode))
+                Ok(tracer
+                    .syscall_mock
+                    .handle_end(exitcode, redirector.stderr.captured()?))
             },
         )
     }

--- a/src/tracer/mod.rs
+++ b/src/tracer/mod.rs
@@ -147,9 +147,7 @@ impl Tracer {
                 let mut tracer = Tracer::new(tracee_pid, mk_syscall_mock(tracee_pid));
                 let exitcode = tracer.trace()?;
                 join()?;
-                Ok(tracer
-                    .syscall_mock
-                    .handle_end(exitcode, redirector.stderr.captured()?))
+                tracer.syscall_mock.handle_end(exitcode, &redirector)
             },
         )
     }

--- a/src/tracer/mod.rs
+++ b/src/tracer/mod.rs
@@ -1,5 +1,5 @@
 mod debugging;
-mod stdio_redirecting;
+pub mod stdio_redirecting;
 pub mod syscall;
 pub mod tracee_memory;
 
@@ -23,7 +23,7 @@ use std::os::unix::ffi::OsStrExt;
 use std::panic;
 use std::path::Path;
 use std::str;
-use stdio_redirecting::Redirector;
+use stdio_redirecting::{CaptureStderr, Redirector};
 use syscall::Syscall;
 use tempdir::TempDir;
 
@@ -119,12 +119,13 @@ impl Tracer {
         program: &Path,
         args: Vec<String>,
         env: HashMap<String, String>,
+        capture_stderr: CaptureStderr,
         mk_syscall_mock: F,
     ) -> R<TestResult>
     where
         F: FnOnce(Pid) -> SyscallMock,
     {
-        let redirector = Redirector::new(context)?;
+        let redirector = Redirector::new(context, capture_stderr)?;
         fork_with_child_errors(
             || {
                 redirector.child_redirect_streams()?;

--- a/src/tracer/stdio_redirecting.rs
+++ b/src/tracer/stdio_redirecting.rs
@@ -13,11 +13,19 @@ pub struct Redirector {
     pub stderr: Redirect,
 }
 
+pub enum CaptureStderr {
+    Capture,
+    NoCapture,
+}
+
 impl Redirector {
-    pub fn new(context: &Context) -> R<Redirector> {
+    pub fn new(context: &Context, capture_stderr: CaptureStderr) -> R<Redirector> {
         Ok(Redirector {
             stdout: Redirect::new(context, StreamType::Stdout)?,
-            stderr: Redirect::new_capturing(context, StreamType::Stderr)?,
+            stderr: match capture_stderr {
+                CaptureStderr::Capture => Redirect::new_capturing(context, StreamType::Stderr)?,
+                CaptureStderr::NoCapture => Redirect::new(context, StreamType::Stderr)?,
+            },
         })
     }
 

--- a/tests/stdio.rs
+++ b/tests/stdio.rs
@@ -10,7 +10,7 @@ mod utils;
 
 use check_protocols::{context::Context, R};
 use test_utils::{trim_margin, TempFile};
-use utils::{test_run_with_context, test_run_with_tempfile};
+use utils::{test_run, test_run_with_context, test_run_with_tempfile};
 
 #[test]
 fn relays_stdout_from_the_tested_script_to_the_user() -> R<()> {
@@ -53,4 +53,48 @@ fn relays_stderr_from_the_tested_script_to_the_user() -> R<()> {
     )?;
     assert_eq!(context.get_captured_stderr(), "foo\n");
     Ok(())
+}
+
+mod expected_stderr {
+    use super::*;
+
+    #[test]
+    fn fails_when_not_matching() -> R<()> {
+        test_run(
+            r##"
+                |#!/usr/bin/env bash
+                |echo bar 1>&2
+            "##,
+            r##"
+                |protocols:
+                |  - protocol: []
+                |    stderr: "foo\n"
+            "##,
+            Err(&trim_margin(
+                r##"
+                    |error:
+                    |  expected output to stderr: "foo\n"
+                    |  received output to stderr: "bar\n"
+                "##,
+            )?),
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn passes_when_matching() -> R<()> {
+        test_run(
+            r##"
+                |#!/usr/bin/env bash
+                |echo foo 1>&2
+            "##,
+            r##"
+                |protocols:
+                |  - protocol: []
+                |    stderr: "foo\n"
+            "##,
+            Ok(()),
+        )?;
+        Ok(())
+    }
 }

--- a/tests/stdio.rs
+++ b/tests/stdio.rs
@@ -97,4 +97,26 @@ mod expected_stderr {
         )?;
         Ok(())
     }
+
+    #[test]
+    fn fails_when_expecting_stderr_but_none_printed() -> R<()> {
+        test_run(
+            r##"
+                |#!/usr/bin/env bash
+            "##,
+            r##"
+                |protocols:
+                |  - protocol: []
+                |    stderr: "foo\n"
+            "##,
+            Err(&trim_margin(
+                r##"
+                    |error:
+                    |  expected output to stderr: "foo\n"
+                    |  received output to stderr: ""
+                "##,
+            )?),
+        )?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
Fixes #87.

There's UI questions I have about this PR:

1. Currently the error messages assume that the output to `stderr` includes a trailing newline. Otherwise they look weird, like this:
```
fooerror:
  expected output to stderr:
bar  received output to stderr:
foo
```
(The first foo is the actual output of the script that is still being relayed, as intended.) Not too sure what to do about this...

2. Usually error messages should contain a trailing newline. With this PR users *have* to specify the trailing newline explicitly, like this:
``` yaml
protocols:
  - protocol: []
    stderr: "foo\n"
```
That's a bit inconvenient, but I don't really know what to do about this. We don't just want to add a newline, if missing, do we?
