### PR TITLE
use Context to write to stdout consistently 

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -4,8 +4,9 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub enum Context {
-    #[cfg(not(feature = "test"))]
-    Context { check_protocols_executable: PathBuf },
+    Context {
+        check_protocols_executable: PathBuf,
+    },
     #[cfg(feature = "test")]
     TestContext {
         stdout: mock_stream::MockStream,
@@ -14,16 +15,10 @@ pub enum Context {
 }
 
 impl Context {
-    #[cfg(not(feature = "test"))]
     pub fn new() -> R<Context> {
         Ok(Context::Context {
             check_protocols_executable: std::env::current_exe()?,
         })
-    }
-
-    #[cfg(feature = "test")]
-    pub fn new() -> R<Context> {
-        Ok(Context::new_mock())
     }
 
     #[cfg(feature = "test")]
@@ -36,7 +31,6 @@ impl Context {
 
     pub fn check_protocols_executable(&self) -> PathBuf {
         match self {
-            #[cfg(not(feature = "test"))]
             Context::Context {
                 check_protocols_executable,
             } => check_protocols_executable.clone(),
@@ -50,7 +44,6 @@ impl Context {
 
     pub fn stdout(&self) -> Box<Write> {
         match self {
-            #[cfg(not(feature = "test"))]
             Context::Context { .. } => Box::new(std::io::stdout()),
             #[cfg(feature = "test")]
             Context::TestContext { stdout, .. } => Box::new(stdout.clone()),
@@ -60,13 +53,13 @@ impl Context {
     #[cfg(feature = "test")]
     pub fn get_captured_stdout(&self) -> String {
         match self {
+            Context::Context { .. } => panic!("tests should use the TestContext"),
             Context::TestContext { stdout, .. } => stdout.get_captured_stream(),
         }
     }
 
     pub fn stderr(&self) -> Box<Write> {
         match self {
-            #[cfg(not(feature = "test"))]
             Context::Context { .. } => Box::new(std::io::stderr()),
             #[cfg(feature = "test")]
             Context::TestContext { stderr, .. } => Box::new(stderr.clone()),
@@ -76,6 +69,7 @@ impl Context {
     #[cfg(feature = "test")]
     pub fn get_captured_stderr(&self) -> String {
         match self {
+            Context::Context { .. } => panic!("tests should use the TestContext"),
             Context::TestContext { stderr, .. } => stderr.get_captured_stream(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,15 +71,11 @@ mod wrap_main {
     }
 }
 
-pub fn run_main(
-    context: &Context,
-    args: impl Iterator<Item = String>,
-    stdout_handle: &mut impl Write,
-) -> R<ExitCode> {
+pub fn run_main(context: &Context, args: impl Iterator<Item = String>) -> R<ExitCode> {
     Ok(match cli::parse_args(args)? {
         cli::Args::ExecutableMock {
             executable_mock_path,
-        } => executable_mock::run(&executable_mock_path, stdout_handle)?,
+        } => executable_mock::run(context, &executable_mock_path)?,
         cli::Args::CheckProtocols { script_path } => run_check_protocols(context, &script_path)?,
     })
 }
@@ -88,7 +84,6 @@ pub fn run_main(
 mod run_main {
     use super::*;
     use executable_mock::create_mock_executable;
-    use std::io::Cursor;
     use test_utils::TempFile;
 
     #[test]
@@ -108,9 +103,8 @@ mod run_main {
             file.path().to_string_lossy().into_owned(),
         ]
         .into_iter();
-        let mut cursor: Cursor<Vec<u8>> = Cursor::new(vec![]);
-        run_main(&context, args, &mut cursor)?;
-        assert_eq!(cursor.into_inner(), b"foo");
+        run_main(&context, args)?;
+        assert_eq!(context.get_captured_stdout(), "foo");
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,6 @@ use check_protocols::{context::Context, run_main, wrap_main};
 fn main() {
     wrap_main(
         |exitcode| exitcode.exit(),
-        || run_main(&Context::new()?, std::env::args(), &mut std::io::stdout()),
+        || run_main(&Context::new()?, std::env::args()),
     );
 }

--- a/src/syscall_mock/executable_mock.rs
+++ b/src/syscall_mock/executable_mock.rs
@@ -26,9 +26,9 @@ pub fn create_mock_executable(context: &Context, config: Config) -> R<Vec<u8>> {
     Ok(result)
 }
 
-pub fn run(executable_mock_path: &Path, stdout_handle: &mut impl Write) -> R<ExitCode> {
+pub fn run(context: &Context, executable_mock_path: &Path) -> R<ExitCode> {
     let config: Config = deserialize(&skip_hashbang_line(fs::read(executable_mock_path)?))?;
-    stdout_handle.write_all(&config.stdout)?;
+    context.stdout().write_all(&config.stdout)?;
     Ok(ExitCode(config.exitcode))
 }
 


### PR DESCRIPTION
I had to revert the commit that removes the production variant of the `Context` during tests. Because for the executable mock tests we need the `check_protocols_executable` to actually write to `stdout` instead of just a captured in-memory `Cursor`. Any other ideas appreciated. Although I also think this is fine...