### PR TITLE
speed up builds in CircleCI with caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,8 @@ jobs:
             apt update
             apt install --yes ruby
       - checkout
+      - restore_cache:
+          key: v1-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run:
           name: check formatting
           command: |
@@ -34,3 +36,8 @@ jobs:
             cp /bin/true /usr/bin/docker
             cargo run -- build-docker-image.sh
             cargo run -- check-protocols-in-docker.sh
+      - save_cache:
+          key: v1-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+          paths:
+            - /usr/local/cargo/registry
+            - target


### PR DESCRIPTION
This change caches dependency download and build steps in CircleCI, which should speed up builds substantially. This is based on information from these sources:

- https://abronan.com/building-a-rust-project-on-circleci/
- https://gist.github.com/zargony/de209b1a790c3cb2176c86405a51b33c
- https://vadosware.io/post/even-faster-rust-builds-in-gitlab-ci/

To summarize, packages and metadata downloaded from crates.io is stored in `$CARGO_HOME/registry`, and the `rust` base image sets `$CARGO_HOME` to `/usr/local/cargo`. Caching `target` includes compiled dependency code in `target/debug/deps`, as well as some other relevant artifacts. Build artifacts from this project are also cached; but AFAICT this will not be a problem for reproducible builds.

The cache key that is configured incorporates the system architecture and a hash of `Cargo.lock`; so the cache will be invalidated if dependencies change.

*Edit:* after one measurement I see a speedup from 1:33 to 0:43.