### PR TITLE
remove unnecessary raw string hashes

### DIFF
--- a/src/protocol/command.rs
+++ b/src/protocol/command.rs
@@ -235,7 +235,7 @@ mod command {
                     Command::new(r#"foo bar\\baz"#)?,
                     Command {
                         executable: b"foo".to_vec(),
-                        arguments: vec![br#"bar\baz"#.to_vec()]
+                        arguments: vec![br"bar\baz".to_vec()]
                     }
                 );
                 Ok(())
@@ -270,26 +270,22 @@ mod command {
 
         roundtrip!(command_and_arguments, "foo bar baz");
 
-        roundtrip!(quoted_argument_with_space, r##"foo "bar baz""##);
+        roundtrip!(quoted_argument_with_space, r#"foo "bar baz""#);
 
-        normalizing_roundtrip!(quoted_argument_without_space, r##"foo "bar""##, "foo bar");
+        normalizing_roundtrip!(quoted_argument_without_space, r#"foo "bar""#, "foo bar");
 
-        roundtrip!(escaped_quotes, r##"foo bar\""##);
+        roundtrip!(escaped_quotes, r#"foo bar\""#);
 
-        normalizing_roundtrip!(
-            escaped_quotes_in_quotes,
-            r##"foo "bar\"""##,
-            r##"foo bar\""##
-        );
+        normalizing_roundtrip!(escaped_quotes_in_quotes, r#"foo "bar\"""#, r#"foo bar\""#);
 
         normalizing_roundtrip!(
             puts_escaped_space_in_quotes,
-            r##"foo bar\ baz"##,
-            r##"foo "bar baz""##
+            r"foo bar\ baz",
+            r#"foo "bar baz""#
         );
 
-        roundtrip!(escaped_newlines, r##"foo bar\nbaz"##);
+        roundtrip!(escaped_newlines, r"foo bar\nbaz");
 
-        roundtrip!(backslash, r##"foo bar\\baz"##);
+        roundtrip!(backslash, r"foo bar\\baz");
     }
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -503,10 +503,10 @@ mod load {
     fn reads_a_protocol_from_a_sibling_yaml_file() -> R<()> {
         assert_eq!(
             test_parse_one(
-                r##"
+                r"
                     |protocol:
                     |  - /bin/true
-                "##,
+                ",
             )?,
             Protocol::new(vec![Step::new(Command {
                 executable: b"/bin/true".to_vec(),
@@ -528,11 +528,11 @@ mod load {
     fn works_for_multiple_commands() -> R<()> {
         assert_eq!(
             test_parse_one(
-                r##"
+                r"
                     |protocol:
                     |  - /bin/true
                     |  - /bin/false
-                "##
+                "
             )?
             .steps
             .map(|step| step.command.executable),
@@ -545,10 +545,10 @@ mod load {
     fn allows_to_specify_arguments() -> R<()> {
         assert_eq!(
             test_parse_one(
-                r##"
+                r"
                     |protocol:
                     |  - /bin/true foo bar
-                "##
+                "
             )?
             .steps
             .map(|step| step.command.arguments),
@@ -561,10 +561,10 @@ mod load {
     fn allows_to_specify_the_protocol_as_an_object() -> R<()> {
         assert_eq!(
             test_parse_one(
-                r##"
+                r"
                     |protocol:
                     |  - /bin/true
-                "##
+                "
             )?,
             Protocol::new(vec![Step::new(Command {
                 executable: b"/bin/true".to_vec(),
@@ -578,12 +578,12 @@ mod load {
     fn allows_to_specify_the_script_environment() -> R<()> {
         assert_eq!(
             test_parse_one(
-                r##"
+                r"
                     |protocol:
                     |  - /bin/true
                     |env:
                     |  foo: bar
-                "##
+                "
             )?
             .env
             .into_iter()
@@ -599,12 +599,12 @@ mod load {
         assert_eq!(
             test_parse(
                 &tempfile,
-                r##"
+                r"
                     |- arguments: foo
                     |  protocol: []
                     |- arguments: bar
                     |  protocol: []
-                "##,
+                ",
             )?
             .protocols
             .map(|protocol| protocol.arguments),
@@ -619,11 +619,11 @@ mod load {
         assert_error!(
             test_parse(
                 &tempfile,
-                r##"
+                r"
                     |protocol: []
                     |---
                     |protocol: []
-                "##,
+                ",
             ),
             format!(
                 "multiple YAML documents not allowed (in {}.protocols.yaml)",
@@ -639,13 +639,13 @@ mod load {
         assert_eq!(
             test_parse(
                 &tempfile,
-                r##"
+                r"
                     |protocols:
                     |  - arguments: foo
                     |    protocol: []
                     |  - arguments: bar
                     |    protocol: []
-                "##,
+                ",
             )?
             .protocols
             .map(|protocol| protocol.arguments),
@@ -677,11 +677,11 @@ mod load {
         fn allows_arguments() -> R<()> {
             assert_eq!(
                 test_parse_one(
-                    r##"
+                    r"
                         |protocol:
                         |  - /bin/true
                         |arguments: foo bar
-                    "##
+                    "
                 )?
                 .arguments,
                 vec!["foo", "bar"]
@@ -693,11 +693,11 @@ mod load {
         fn allows_arguments_with_whitespace() -> R<()> {
             assert_eq!(
                 test_parse_one(
-                    r##"
+                    r#"
                         |protocol:
                         |  - /bin/true
                         |arguments: foo "bar baz"
-                    "##
+                    "#
                 )?
                 .arguments,
                 vec!["foo", "bar baz"]
@@ -711,11 +711,11 @@ mod load {
             assert_error!(
                 test_parse(
                     &tempfile,
-                    r##"
+                    r"
                         |protocol:
                         |  - /bin/true
                         |arguments: 42
-                    "##
+                    "
                 ),
                 format!(
                     "unexpected type in {}.protocols.yaml: \
@@ -735,11 +735,11 @@ mod load {
         fn allows_to_specify_the_working_directory() -> R<()> {
             assert_eq!(
                 test_parse_one(
-                    r##"
+                    r"
                         |protocol:
                         |  - /bin/true
                         |cwd: /foo
-                    "##
+                    "
                 )?
                 .cwd,
                 Some(b"/foo".to_vec())
@@ -751,10 +751,10 @@ mod load {
         fn none_is_the_default() -> R<()> {
             assert_eq!(
                 test_parse_one(
-                    r##"
+                    r"
                         |protocol:
                         |  - /bin/true
-                    "##
+                    "
                 )?
                 .cwd,
                 None
@@ -765,11 +765,11 @@ mod load {
         #[test]
         fn disallows_relative_paths() -> R<()> {
             let yaml = YamlLoader::load_from_str(&trim_margin(
-                r##"
+                r"
                     |protocol:
                     |  - /bin/true
                     |cwd: foo
-                "##,
+                ",
             )?)?;
             assert_error!(
                 Protocols::parse(yaml[0].clone()),
@@ -787,11 +787,11 @@ mod load {
         fn allows_to_specify_the_expected_exit_code() -> R<()> {
             assert_eq!(
                 test_parse_one(
-                    r##"
+                    r"
                         |protocol:
                         |  - /bin/true
                         |exitcode: 42
-                    "##
+                    "
                 )?
                 .exitcode,
                 Some(42)
@@ -803,10 +803,10 @@ mod load {
         fn uses_none_as_the_default() -> R<()> {
             assert_eq!(
                 test_parse_one(
-                    r##"
+                    r"
                         |protocol:
                         |  - /bin/true
-                    "##
+                    "
                 )?
                 .exitcode,
                 None
@@ -825,12 +825,12 @@ mod load {
             assert_eq!(
                 test_parse(
                     &tempfile,
-                    r##"
+                    r"
                         |protocols:
                         |  - protocol: []
                         |unmockedCommands:
                         |  - foo
-                    "##
+                    "
                 )?
                 .unmocked_commands
                 .map(|command| String::from_utf8(command).unwrap()),
@@ -850,11 +850,11 @@ mod load {
             assert_eq!(
                 test_parse(
                     &tempfile,
-                    r##"
+                    r"
                         |protocols:
                         |  - protocol: []
                         |interpreter: /bin/bash
-                    "##,
+                    ",
                 )?
                 .interpreter
                 .unwrap(),
@@ -869,11 +869,11 @@ mod load {
             assert_error!(
                 test_parse(
                     &tempfile,
-                    r##"
+                    r"
                         |protocols:
                         |  - protocol: []
                         |interpreter: 42
-                    "##,
+                    ",
                 ),
                 format!(
                     "unexpected type in {}.protocols.yaml: \
@@ -889,11 +889,11 @@ mod load {
     fn allows_to_specify_mocked_files() -> R<()> {
         assert_eq!(
             test_parse_one(
-                r##"
+                r"
                     |protocol: []
                     |mockedFiles:
                     |  - /foo
-                "##
+                "
             )?
             .mocked_files
             .map(|path| String::from_utf8_lossy(&path).into_owned()),
@@ -910,10 +910,10 @@ mod load {
         fn allows_to_specify_the_expected_stderr() -> R<()> {
             assert_eq!(
                 test_parse_one(
-                    r##"
+                    r"
                         |- protocol: []
                         |  stderr: foo
-                    "##
+                    "
                 )?
                 .stderr
                 .map(|s| String::from_utf8(s).unwrap()),
@@ -926,9 +926,9 @@ mod load {
         fn none_is_the_default() -> R<()> {
             assert_eq!(
                 test_parse_one(
-                    r##"
+                    r"
                         |- protocol: []
-                    "##
+                    "
                 )?
                 .stderr,
                 None
@@ -945,11 +945,11 @@ mod load {
         fn parses_underscores_as_holes() -> R<()> {
             assert_eq!(
                 test_parse_one(
-                    r##"
+                    r"
                         |protocols:
                         |  - protocol:
                         |      - _
-                    "##
+                    "
                 )?
                 .ends_with_hole,
                 true
@@ -961,11 +961,11 @@ mod load {
         fn false_is_the_default() -> R<()> {
             assert_eq!(
                 test_parse_one(
-                    r##"
+                    r"
                         |protocols:
                         |  - protocol:
                         |      - /bin/foo
-                    "##
+                    "
                 )?
                 .ends_with_hole,
                 false
@@ -979,12 +979,12 @@ mod load {
             assert_error!(
                 test_parse(
                     &tempfile,
-                    r##"
+                    r"
                         |protocols:
                         |  - protocol:
                         |      - _
                         |      - /bin/foo
-                    "##
+                    "
                 ),
                 format!(
                     "unexpected type in {}.protocols.yaml: holes ('_') are only allowed as the last step",

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -14,14 +14,14 @@ use utils::test_run;
 #[test]
 fn looks_up_step_executable_in_path() -> R<()> {
     test_run(
-        r##"
+        r"
             |#!/usr/bin/env bash
             |cp
-        "##,
-        r##"
+        ",
+        r"
             |protocol:
             |  - cp
-        "##,
+        ",
         Ok(()),
     )?;
     Ok(())
@@ -30,16 +30,16 @@ fn looks_up_step_executable_in_path() -> R<()> {
 #[test]
 fn looks_up_unmocked_command_executable_in_path() -> R<()> {
     test_run(
-        r##"
+        r"
             |#!/usr/bin/env bash
             |ls > /dev/null
-        "##,
-        r##"
+        ",
+        r"
             |protocols:
             |  - protocol: []
             |unmockedCommands:
             |  - ls
-        "##,
+        ",
         Ok(()),
     )?;
     Ok(())
@@ -48,14 +48,14 @@ fn looks_up_unmocked_command_executable_in_path() -> R<()> {
 #[test]
 fn shortens_received_executable_to_file_name_when_reporting_step_error() -> R<()> {
     test_run(
-        r##"
+        r"
             |#!/usr/bin/env bash
             |mv
-        "##,
-        r##"
+        ",
+        r"
             |protocol:
             |  - cp
-        "##,
+        ",
         Err(&trim_margin(
             "
                 |error:
@@ -70,14 +70,14 @@ fn shortens_received_executable_to_file_name_when_reporting_step_error() -> R<()
 #[test]
 fn runs_step_executable_that_is_not_in_path() -> R<()> {
     test_run(
-        r##"
+        r"
             |#!/usr/bin/env bash
             |/not/in/path
-        "##,
-        r##"
+        ",
+        r"
             |protocol:
             |  - /not/in/path
-        "##,
+        ",
         Ok(()),
     )?;
     Ok(())

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -19,14 +19,14 @@ use utils::{prepare_script, test_run, test_run_with_tempfile};
 #[test]
 fn simple() -> R<()> {
     test_run(
-        r##"
+        r"
             |#!/usr/bin/env bash
             |cp
-        "##,
-        r##"
+        ",
+        r"
             |protocol:
             |  - cp
-        "##,
+        ",
         Ok(()),
     )?;
     Ok(())
@@ -66,10 +66,10 @@ fn works_for_longer_file_names() -> R<()> {
     fs::copy("/bin/true", &long_command_path)?;
     let (script, _) = prepare_script(
         &format!(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |{}
-            "##,
+            ",
             &long_command_path
         ),
         &format!(
@@ -90,15 +90,15 @@ fn works_for_longer_file_names() -> R<()> {
 #[test]
 fn can_specify_interpreter() -> R<()> {
     test_run(
-        r##"
+        r"
             |`true`
-        "##,
-        r##"
+        ",
+        r#"
             |protocols:
             |  - protocol:
             |    - "true"
             |interpreter: /usr/bin/ruby
-        "##,
+        "#,
         Ok(()),
     )?;
     Ok(())
@@ -114,9 +114,9 @@ mod yaml_parse_errors {
         let result = test_run_with_tempfile(
             &Context::new_mock(),
             &script,
-            r##"
+            r"
                 |protocol: 42
-            "##,
+            ",
         );
         assert_error!(
             result,
@@ -135,9 +135,9 @@ mod yaml_parse_errors {
         let result = test_run_with_tempfile(
             &Context::new_mock(),
             &script,
-            r##"
+            r"
                 |protocol: - boo
-            "##,
+            ",
         );
         assert_error!(
             result,
@@ -155,16 +155,16 @@ mod yaml_parse_errors {
 #[test]
 fn multiple() -> R<()> {
     test_run(
-        r##"
+        r"
             |#!/usr/bin/env bash
             |cp
             |ls > /dev/null
-        "##,
-        r##"
+        ",
+        r"
             |protocol:
             |  - cp
             |  - ls
-        "##,
+        ",
         Ok(()),
     )?;
     Ok(())
@@ -173,14 +173,14 @@ fn multiple() -> R<()> {
 #[test]
 fn failing() -> R<()> {
     test_run(
-        r##"
+        r"
             |#!/usr/bin/env bash
             |mv
-        "##,
-        r##"
+        ",
+        r"
             |protocol:
             |  - cp
-        "##,
+        ",
         Err(&trim_margin(
             "
                 |error:
@@ -195,16 +195,16 @@ fn failing() -> R<()> {
 #[test]
 fn failing_later() -> R<()> {
     test_run(
-        r##"
+        r"
             |#!/usr/bin/env bash
             |ls
             |mv
-        "##,
-        r##"
+        ",
+        r"
             |protocol:
             |  - ls
             |  - cp
-        "##,
+        ",
         Err(&trim_margin(
             "
                 |error:
@@ -232,29 +232,29 @@ mod nice_user_errors {
     fn nice_error_when_hashbang_refers_to_missing_interpreter() -> R<()> {
         let script = TempFile::write_temp_script(
             trim_margin(
-                r##"
+                r"
                     |#!/usr/bin/foo
                     |cp
-                "##,
+                ",
             )?
             .as_bytes(),
         )?;
         let result = test_run_with_tempfile(
             &Context::new_mock(),
             &script,
-            r##"
+            r"
                 |protocol:
                 |  - cp
-            "##,
+            ",
         );
         assert_error!(
             result,
             trim_margin(
                 format!(
-                    r##"
+                    r"
                         |execve'ing {} failed with error: ENOENT: No such file or directory
                         |Does #!/usr/bin/foo exist?
-                    "##,
+                    ",
                     path_to_string(script.path().as_ref())?
                 )
                 .as_str(),
@@ -268,28 +268,28 @@ mod nice_user_errors {
     fn nice_error_when_hashbang_missing() -> R<()> {
         let script = TempFile::write_temp_script(
             trim_margin(
-                r##"
+                r"
                     |cp
-                "##,
+                ",
             )?
             .as_bytes(),
         )?;
         let result = test_run_with_tempfile(
             &Context::new_mock(),
             &script,
-            r##"
+            r"
                 |protocol:
                 |  - cp
-            "##,
+            ",
         );
         assert_error!(
             result,
             trim_margin(
                 format!(
-                    r##"
+                    r"
                         |execve'ing {} failed with error: ENOEXEC: Exec format error
                         |Does your interpreter exist?
-                    "##,
+                    ",
                     path_to_string(script.path().as_ref())?
                 )
                 .as_str(),
@@ -303,30 +303,30 @@ mod nice_user_errors {
     fn nice_error_when_yaml_refers_to_missing_interpreter() -> R<()> {
         let script = TempFile::write_temp_script(
             trim_margin(
-                r##"
+                r"
                     |`true`
-                "##,
+                ",
             )?
             .as_bytes(),
         )?;
         let result = test_run_with_tempfile(
             &Context::new_mock(),
             &script,
-            r##"
+            r"
                 |protocols:
                 |  - protocol:
                 |    - cp
                 |interpreter: /usr/bin/foo
-            "##,
+            ",
         );
         assert_error!(
             result,
             trim_margin(
                 format!(
-                    r##"
+                    r"
                         |execve'ing {} failed with error: ENOENT: No such file or directory
                         |Does /usr/bin/foo exist?
-                    "##,
+                    ",
                     path_to_string(script.path().as_ref())?
                 )
                 .as_str(),
@@ -343,14 +343,14 @@ mod arguments {
     #[test]
     fn arguments() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |cp foo
-            "##,
-            r##"
+            ",
+            r"
                 |protocol:
                 |  - cp foo
-            "##,
+            ",
             Ok(()),
         )?;
         Ok(())
@@ -359,14 +359,14 @@ mod arguments {
     #[test]
     fn failing_arguments() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |cp bar
-            "##,
-            r##"
+            ",
+            r"
                 |protocol:
                 |  - cp foo
-            "##,
+            ",
             Err(&trim_margin(
                 "
                     |error:
@@ -381,14 +381,14 @@ mod arguments {
     #[test]
     fn arguments_with_spaces() -> R<()> {
         test_run(
-            r##"
+            r#"
                 |#!/usr/bin/env bash
                 |cp "foo bar"
-            "##,
-            r##"
+            "#,
+            r#"
                 |protocol:
                 |  - cp "foo bar"
-            "##,
+            "#,
             Ok(()),
         )?;
         Ok(())
@@ -397,20 +397,20 @@ mod arguments {
     #[test]
     fn error_messages_maintain_quotes() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |cp foo bar
-            "##,
-            r##"
+            ",
+            r#"
                 |protocol:
                 |  - cp "foo bar"
-            "##,
+            "#,
             Err(&trim_margin(
-                r##"
+                r#"
                     |error:
                     |  expected: cp "foo bar"
                     |  received: cp foo bar
-                "##,
+                "#,
             )?),
         )?;
         Ok(())
@@ -420,16 +420,16 @@ mod arguments {
 #[test]
 fn reports_the_first_error() -> R<()> {
     test_run(
-        r##"
+        r"
             |#!/usr/bin/env bash
             |mv first
             |mv second
-        "##,
-        r##"
+        ",
+        r"
             |protocol:
             |  - cp first
             |  - cp second
-        "##,
+        ",
         Err(&trim_margin(
             "
                 |error:
@@ -447,15 +447,15 @@ mod mismatch_in_number_of_commands {
     #[test]
     fn more_expected_commands() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |ls
-            "##,
-            r##"
+            ",
+            r"
                 |protocol:
                 |  - ls
                 |  - cp
-            "##,
+            ",
             Err(&trim_margin(
                 "
                     |error:
@@ -470,15 +470,15 @@ mod mismatch_in_number_of_commands {
     #[test]
     fn more_received_commands() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |ls
                 |cp
-            "##,
-            r##"
+            ",
+            r"
                 |protocol:
                 |  - ls
-            "##,
+            ",
             Err(&trim_margin(
                 "
                     |error:
@@ -497,17 +497,17 @@ mod stdout {
     #[test]
     fn mock_stdout() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |output=$(cp)
                 |cp $output
-            "##,
-            r##"
+            ",
+            r"
                 |protocol:
                 |  - command: cp
                 |    stdout: test_output
                 |  - cp test_output
-            "##,
+            ",
             Ok(()),
         )?;
         Ok(())
@@ -516,17 +516,17 @@ mod stdout {
     #[test]
     fn mock_stdout_with_special_characters() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |output=$(cp)
                 |cp $output
-            "##,
-            r##"
+            ",
+            r#"
                 |protocol:
                 |  - command: cp
                 |    stdout: 'foo"'
                 |  - 'cp foo\"'
-            "##,
+            "#,
             Ok(()),
         )?;
         Ok(())
@@ -535,17 +535,17 @@ mod stdout {
     #[test]
     fn mock_stdout_with_newlines() -> R<()> {
         test_run(
-            r##"
+            r#"
                 |#!/usr/bin/env bash
                 |output=$(cp)
                 |cp "$output"
-            "##,
-            r##"
+            "#,
+            r#"
                 |protocol:
                 |  - command: cp
                 |    stdout: "foo\nbar"
                 |  - 'cp foo\nbar'
-            "##,
+            "#,
             Ok(()),
         )?;
         Ok(())
@@ -555,15 +555,15 @@ mod stdout {
 #[test]
 fn pass_arguments_into_tested_script() -> R<()> {
     test_run(
-        r##"
+        r"
             |#!/usr/bin/env bash
             |cp $1
-        "##,
-        r##"
+        ",
+        r"
             |arguments: foo
             |protocol:
             |  - cp foo
-        "##,
+        ",
         Ok(()),
     )?;
     Ok(())
@@ -575,18 +575,18 @@ mod multiple_protocols {
     #[test]
     fn all_pass() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |cp $1
-            "##,
-            r##"
+            ",
+            r"
                 |- arguments: foo
                 |  protocol:
                 |    - cp foo
                 |- arguments: bar
                 |  protocol:
                 |    - cp bar
-            "##,
+            ",
             Ok(()),
         )?;
         Ok(())
@@ -595,16 +595,16 @@ mod multiple_protocols {
     #[test]
     fn all_fail() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |mv
-            "##,
-            r##"
+            ",
+            r"
                 |- protocol:
                 |    - cp
                 |- protocol:
                 |    - cp
-            "##,
+            ",
             Err(&trim_margin(
                 "
                     |error in protocol 1:
@@ -622,16 +622,16 @@ mod multiple_protocols {
     #[test]
     fn some_fail() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |mv
-            "##,
-            r##"
+            ",
+            r"
                 |- protocol:
                 |    - mv
                 |- protocol:
                 |    - cp
-            "##,
+            ",
             Err(&trim_margin(
                 "
                     |protocol 1:
@@ -652,16 +652,16 @@ mod environment {
     #[test]
     fn pass_env_into_tested_script() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |cp $FOO
-            "##,
-            r##"
+            ",
+            r"
                 |env:
                 |  FOO: test-env-var
                 |protocol:
                 |  - cp test-env-var
-            "##,
+            ",
             Ok(()),
         )?;
         Ok(())
@@ -671,14 +671,14 @@ mod environment {
     fn does_not_inherit_the_parent_env() -> R<()> {
         std::env::set_var("FOO", "bar");
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |cp $FOO
-            "##,
-            r##"
+            ",
+            r"
                 |protocol:
                 |  - cp
-            "##,
+            ",
             Ok(()),
         )?;
         Ok(())
@@ -688,14 +688,14 @@ mod environment {
 #[test]
 fn detects_running_commands_from_ruby_scripts() -> R<()> {
     test_run(
-        r##"
+        r"
             |#!/usr/bin/env ruby
             |`ls`
-        "##,
-        r##"
+        ",
+        r"
             |protocol:
             |  - ls
-        "##,
+        ",
         Ok(()),
     )?;
     Ok(())
@@ -707,18 +707,18 @@ mod mocked_exitcodes {
     #[test]
     fn set_a_non_zero_exitcode() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |if !(grep foo) ; then
                 |  ls
                 |fi
-            "##,
-            r##"
+            ",
+            r"
                 |protocol:
                 |  - command: grep foo
                 |    exitcode: 1
                 |  - ls
-            "##,
+            ",
             Ok(()),
         )?;
         Ok(())
@@ -727,18 +727,18 @@ mod mocked_exitcodes {
     #[test]
     fn set_a_zero_exitcode() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |if grep foo ; then
                 |  ls
                 |fi
-            "##,
-            r##"
+            ",
+            r"
                 |protocol:
                 |  - command: grep foo
                 |    exitcode: 0
                 |  - ls
-            "##,
+            ",
             Ok(()),
         )?;
         Ok(())
@@ -747,17 +747,17 @@ mod mocked_exitcodes {
     #[test]
     fn uses_a_zero_exitcode_by_default() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |if grep foo ; then
                 |  ls
                 |fi
-            "##,
-            r##"
+            ",
+            r"
                 |protocol:
                 |  - grep foo
                 |  - ls
-            "##,
+            ",
             Ok(()),
         )?;
         Ok(())
@@ -766,17 +766,17 @@ mod mocked_exitcodes {
     #[test]
     fn allow_to_specify_the_exact_exitcode() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |grep foo
                 |ls $?
-            "##,
-            r##"
+            ",
+            r"
                 |protocol:
                 |  - command: grep foo
                 |    exitcode: 42
                 |  - ls 42
-            "##,
+            ",
             Ok(()),
         )?;
         Ok(())
@@ -789,15 +789,15 @@ mod working_directory {
     #[test]
     fn allows_to_specify_the_working_directory() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |ls $(pwd)/file
-            "##,
-            r##"
+            ",
+            r"
                 |cwd: /foo
                 |protocol:
                 |  - ls /foo/file
-            "##,
+            ",
             Ok(()),
         )?;
         Ok(())
@@ -806,15 +806,15 @@ mod working_directory {
     #[test]
     fn works_for_long_paths() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |ls $(pwd)/file
-            "##,
-            r##"
+            ",
+            r"
                 |cwd: /foo/bar/baz/foo/bar/baz/foo/bar/baz/foo
                 |protocol:
                 |  - ls /foo/bar/baz/foo/bar/baz/foo/bar/baz/foo/file
-            "##,
+            ",
             Ok(()),
         )?;
         Ok(())
@@ -824,15 +824,15 @@ mod working_directory {
     fn inherits_the_working_directory_if_not_specified() -> R<()> {
         let cwd = env::current_dir()?;
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |ls $(pwd)/foo
-            "##,
+            ",
             &format!(
-                r##"
+                r"
                     |protocol:
                     |  - ls {}/foo
-                "##,
+                ",
                 path_to_string(&cwd)?
             ),
             Ok(()),
@@ -847,13 +847,13 @@ mod expected_exitcode {
     #[test]
     fn failure_when_the_tested_script_exits_with_a_non_zero_exitcode() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |exit 42
-            "##,
-            r##"
+            ",
+            r"
                 |protocol: []
-            "##,
+            ",
             Err(&trim_margin(
                 "
                     |error:
@@ -868,14 +868,14 @@ mod expected_exitcode {
     #[test]
     fn expect_non_zero_exitcode_passing() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |exit 42
-            "##,
-            r##"
+            ",
+            r"
                 |protocol: []
                 |exitcode: 42
-            "##,
+            ",
             Ok(()),
         )?;
         Ok(())
@@ -884,14 +884,14 @@ mod expected_exitcode {
     #[test]
     fn expect_non_zero_exitcode_failing() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |true
-            "##,
-            r##"
+            ",
+            r"
                 |protocol: []
                 |exitcode: 42
-            "##,
+            ",
             Err(&trim_margin(
                 "
                 |error:
@@ -910,17 +910,17 @@ mod unmocked_commands {
     #[test]
     fn allows_to_unmock_commands() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |ls $(dirname dir/file)
-            "##,
-            r##"
+            ",
+            r"
                 |protocols:
                 |  - protocol:
                 |    - ls dir
                 |unmockedCommands:
                 |  - dirname
-            "##,
+            ",
             Ok(()),
         )?;
         Ok(())
@@ -929,18 +929,18 @@ mod unmocked_commands {
     #[test]
     fn complains_when_expected_an_unmocked_command() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |ls $(dirname dir/file)
-            "##,
-            r##"
+            ",
+            r"
                 |protocols:
                 |  - protocol:
                 |    - dirname dir/file
                 |    - ls dir
                 |unmockedCommands:
                 |  - dirname
-            "##,
+            ",
             Err(&trim_margin(
                 "
                     |error:
@@ -959,19 +959,19 @@ mod file_mocking {
     #[test]
     fn allows_to_mock_files_existence() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |if [ -f /foo ]; then
                 |  cp
                 |fi
-            "##,
-            r##"
+            ",
+            r"
                 |protocols:
                 |  - protocol:
                 |      - cp
                 |    mockedFiles:
                 |      - /foo
-            "##,
+            ",
             Ok(()),
         )?;
         Ok(())
@@ -980,19 +980,19 @@ mod file_mocking {
     #[test]
     fn allows_to_mock_directory_existence() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |if [ -d /foo/ ]; then
                 |  cp
                 |fi
-            "##,
-            r##"
+            ",
+            r"
                 |protocols:
                 |  - protocol:
                 |      - command: cp
                 |    mockedFiles:
                 |      - /foo/
-            "##,
+            ",
             Ok(()),
         )?;
         Ok(())
@@ -1001,16 +1001,16 @@ mod file_mocking {
     #[test]
     fn does_not_mock_existence_of_unspecified_files() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |if [ -f /foo ]; then
                 |  cp
                 |fi
-            "##,
-            r##"
+            ",
+            r"
                 |protocols:
                 |  - protocol: []
-            "##,
+            ",
             Ok(()),
         )?;
         Ok(())

--- a/tests/stdio.rs
+++ b/tests/stdio.rs
@@ -17,20 +17,20 @@ fn relays_stdout_from_the_tested_script_to_the_user() -> R<()> {
     let context = Context::new_mock();
     let script = TempFile::write_temp_script(
         trim_margin(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |echo foo
-            "##,
+            ",
         )?
         .as_bytes(),
     )?;
     test_run_with_tempfile(
         &context,
         &script,
-        r##"
+        r"
             |protocols:
             |  - protocol: []
-        "##,
+        ",
     )?;
     assert_eq!(context.get_captured_stdout(), "foo\nAll tests passed.\n");
     Ok(())
@@ -41,14 +41,14 @@ fn relays_stderr_from_the_tested_script_to_the_user() -> R<()> {
     let context = Context::new_mock();
     test_run_with_context(
         &context,
-        r##"
+        r"
             |#!/usr/bin/env bash
             |echo foo 1>&2
-        "##,
-        r##"
+        ",
+        r"
             |protocols:
             |  - protocol: []
-        "##,
+        ",
         Ok(()),
     )?;
     assert_eq!(context.get_captured_stderr(), "foo\n");
@@ -61,21 +61,21 @@ mod expected_stderr {
     #[test]
     fn fails_when_not_matching() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |echo bar 1>&2
-            "##,
-            r##"
+            ",
+            r#"
                 |protocols:
                 |  - protocol: []
                 |    stderr: "foo\n"
-            "##,
+            "#,
             Err(&trim_margin(
-                r##"
+                r#"
                     |error:
                     |  expected output to stderr: "foo\n"
                     |  received output to stderr: "bar\n"
-                "##,
+                "#,
             )?),
         )?;
         Ok(())
@@ -84,15 +84,15 @@ mod expected_stderr {
     #[test]
     fn passes_when_matching() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
                 |echo foo 1>&2
-            "##,
-            r##"
+            ",
+            r#"
                 |protocols:
                 |  - protocol: []
                 |    stderr: "foo\n"
-            "##,
+            "#,
             Ok(()),
         )?;
         Ok(())
@@ -101,20 +101,20 @@ mod expected_stderr {
     #[test]
     fn fails_when_expecting_stderr_but_none_printed() -> R<()> {
         test_run(
-            r##"
+            r"
                 |#!/usr/bin/env bash
-            "##,
-            r##"
+            ",
+            r#"
                 |protocols:
                 |  - protocol: []
                 |    stderr: "foo\n"
-            "##,
+            "#,
             Err(&trim_margin(
-                r##"
+                r#"
                     |error:
                     |  expected output to stderr: "foo\n"
                     |  received output to stderr: ""
-                "##,
+                "#,
             )?),
         )?;
         Ok(())


### PR DESCRIPTION
Here's some documentation on how raw strings work: https://doc.rust-lang.org/reference/tokens.html#raw-string-literals

This is a pretty mechanical PR.

Fixes #163.