### PR TITLE
throw errors when unknown yaml fields are encountered

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
-#![cfg_attr(feature = "dev", allow(dead_code, unused_variables, unused_imports))]
+#![cfg_attr(
+    feature = "dev",
+    allow(dead_code, unused_variables, unused_imports, unreachable_code)
+)]
 #![cfg_attr(feature = "ci", deny(warnings))]
 #![deny(clippy::all)]
 #![allow(clippy::needless_range_loop, clippy::large_enum_variant)]

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -121,7 +121,7 @@ mod yaml_parse_errors {
         assert_error!(
             result,
             format!(
-                "unexpected type in {}.protocols.yaml: \
+                "error in {}.protocols.yaml: \
                  expected: array, got: Integer(42)",
                 path_to_string(&script.path())?
             )


### PR DESCRIPTION
Fixes #38.

I think it's better to throw an error to avoid users accidentally missing this.